### PR TITLE
Fixing liquid error

### DIFF
--- a/people.md
+++ b/people.md
@@ -3,7 +3,7 @@ title: People
 permalink: /people/
 ---
 
-{% assign people_sorted = (site.people | sort: 'joined') %}
+{% assign people_sorted = site.people | sort: 'joined' %}
 {% assign people_array = "pi|researcher|phd|ms|undergrad|visiting" | split: "|" %}
 
 {% for item in people_array %}

--- a/publications.md
+++ b/publications.md
@@ -3,7 +3,7 @@ title: Publications
 permalink: /publications/
 ---
 
-{% assign pub_sorted = (site.publications | sort: 'date') %}
+{% assign pub_sorted = site.publications | sort: 'date' %}
 {% assign pub_array = "pub|standard|draft" | split: "|" %}
 {% assign year_array = "2018|2017|2016|2015|2014|2013|2012|2011|2010|2009|2008|2007|2006|2005" | split: "|" %}
 


### PR DESCRIPTION
I was getting a liquid error for publications and people which was:
```
    Liquid Warning: Liquid syntax error (line 1): Expected dotdot but found pipe in "{{(site.people | sort: 'joined') }}" in people.md
    Liquid Warning: Liquid syntax error (line 1): Expected dotdot but found pipe in "{{(site.publications | sort: 'date') }}" in publications.md
```

This fixes it. The site works locally.