### PR TITLE
Remove double underline from mouseover/focus on links

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -49,14 +49,6 @@ a:visited {
   color: #993300;
 }
 
-a:focus {
-  border-bottom: 1px solid;
-}
-
-a:hover {
-  border-bottom: 1px solid;
-}
-
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
   margin-bottom: .5rem;


### PR DESCRIPTION
Remove redundant double line when moving over links.