### PR TITLE
Separate projects template from publications template.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,7 +66,7 @@ defaults:
       path:         ""
       type:         "publications"
     values:
-      layout:       "projects"
+      layout:       "publications"
   -
     scope:
       path:         ""

--- a/_layouts/publications.html
+++ b/_layouts/publications.html
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+<div class="container content projects">
+  <h1 class="page-title">{{ page.title }}</h1>
+	  {{ content }}
+</div>


### PR DESCRIPTION
This separates the templates for publications and projects. Publications abstracts do not necessarily need a figure.

This fixes issue #70