### PR TITLE
Fix/travis

### DIFF
--- a/people.md
+++ b/people.md
@@ -29,7 +29,7 @@ permalink: /people/
 <hr>
 
 <h3>Alumni</h3>
-<dl style="font-size:0.7rem;">
+<ul style="font-size:0.7rem;">
 <li>Ming Tai Ha</li>
 <li>Ole Weidner</li>
 <li>Franklin Bettencourt</li>
@@ -49,3 +49,4 @@ permalink: /people/
 <li>Hartmut Kaiser)</li>
 <li>Ashley Zebrowski</li>
 <li>Aikaterina Stamou</li>
+</ul>

--- a/people.md
+++ b/people.md
@@ -14,7 +14,7 @@ permalink: /people/
     <div class="list-item-people">
       <p class="list-post-title">
         {% if profile.avatar %}
-        <a href="{{ site.baseurl }}{{ profile.url }}"><img width="200" src="{{site.baseurl}}/images/people/{{profile.avatar}}"></a>
+        <a href="{{ site.baseurl }}{{ profile.url }}"><img width="200" src="{{site.baseurl}}/images/people/{{profile.avatar}}" alt="{{profile.name}} photo"></a>
         {% else %}
         <a href="{{ site.baseurl }}{{ profile.url }}"><img width="200" src="http://evansheline.com/wp-content/uploads/2011/02/facebook-Storm-Trooper.jpg"></a>
         {% endif %}

--- a/people.md
+++ b/people.md
@@ -49,4 +49,3 @@ permalink: /people/
 <li>Hartmut Kaiser)</li>
 <li>Ashley Zebrowski</li>
 <li>Aikaterina Stamou</li>
-</dl>


### PR DESCRIPTION
This separates the templates for publications and projects. Publications abstracts do not necessarily need a figure.

This fixes issue #74 
Travis fails with `IEEE` because their site is down.