### PR TITLE
Fixes issue #95

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -605,6 +605,15 @@ tbody tr:nth-child(odd) th {
   grid-gap: 50px;
 }
 
+@media(max-width: 38em){
+  .grid-container {
+    display: grid;
+    grid-template-columns: auto auto;
+    grid-gap: 50px;
+  }
+}
+
+
 .pub-page-title {
   text-align: center;
   margin-bottom: 0.6em;


### PR DESCRIPTION
I propose the following to fix #95.

It adds a check in the CSS file for media with a maximum width of 38 em. If it is smaller, the grid becomes as two column instead of three.